### PR TITLE
fix conflicting build IDs

### DIFF
--- a/Signal-Desktop.spec
+++ b/Signal-Desktop.spec
@@ -46,6 +46,9 @@ matter to you.
 Signal Desktop is an Electron application that links with Signal on Android or
 iOS.
 
+# Build id links are sometimes in conflict with other RPMs.
+%define _build_id_links none
+
 %prep
 %autosetup -p1 -n %{name}-%{version}%{?beta:-%{beta}}
 


### PR DESCRIPTION
I got this fix from [Lens](https://github.com/lensapp/lens/pull/4464/files), which is also an example of an RPM that until recently was conflicting with these ones.

This is a simple fix that should solve it for future packages that might have conflicting build ID links.