### PR TITLE
Set StartupWMClass in desktop file

### DIFF
--- a/org.signal.Signal.desktop
+++ b/org.signal.Signal.desktop
@@ -8,3 +8,4 @@ Exec=signal-desktop --use-tray-icon
 Categories=Network
 StartupNotify=true
 MimeType=x-scheme-handler/sgnl;
+StartupWMClass=signal


### PR DESCRIPTION
I was having trouble with Signal creating a second "signal" icon in the activity bar when launched. This fixes that.

I run Fedora 43